### PR TITLE
Make cla-bot work with any repo in organisation

### DIFF
--- a/src/clabot-sample.coffee
+++ b/src/clabot-sample.coffee
@@ -14,16 +14,24 @@ bodyParser = require('body-parser')
 # create secrets object
 secrets = {}
 secrets[process.env.GITHUB_REPO_OWNER] = {}
-secrets[process.env.GITHUB_REPO_OWNER][process.env.GITHUB_REPO] = process.env.HUB_SECRET
+secrets[process.env.GITHUB_REPO_OWNER]['rhododendron'] = process.env.HUB_SECRET
+secrets[process.env.GITHUB_REPO_OWNER]['parity-ethereum'] = process.env.HUB_SECRET
+secrets[process.env.GITHUB_REPO_OWNER]['sol-rs'] = process.env.HUB_SECRET
+secrets[process.env.GITHUB_REPO_OWNER]['substrate'] = process.env.HUB_SECRET
+secrets[process.env.GITHUB_REPO_OWNER]['polkadot'] = process.env.HUB_SECRET
+secrets[process.env.GITHUB_REPO_OWNER][''] = process.env.HUB_SECRET
 
-console.log('Serving Github Repos: ', process.env.GITHUB_REPO_OWNER, process.env.GITHUB_REPO)
-console.log('Domain is: ', process.env.DOMAIN)
+# domain url
+domain = process.env.DOMAIN
+domain = 'https://' + hostname + '.cla.parity.io'
+console.log('Serving Github Repos: ', process.env.GITHUB_REPO_OWNER)
+console.log('Domain is: ', domain)
 
 # set up authentication
 passport.use new GitHubStrategy
   clientID: process.env.CLIENT_ID
   clientSecret: process.env.CLIENT_SECRET
-  callbackURL: process.env.DOMAIN + "/auth/github/callback"
+  callbackURL: domain + "/auth/github/callback"
 , (accessToken, refreshToken, profile, cb) ->
   data.saveOrCreateSigner profile, (err) ->
     cb(err, profile)
@@ -45,7 +53,7 @@ appObj =
   skipCollaborators: true
   skipContributors: true
   templateData:
-    link: "#{process.env.DOMAIN}"
+    link: "#{domain}"
     maintainer: 'paritytech'
   templates:
     notYetSigned: """

--- a/src/clabot-sample.coffee
+++ b/src/clabot-sample.coffee
@@ -19,7 +19,6 @@ secrets[process.env.GITHUB_REPO_OWNER]['parity-ethereum'] = process.env.HUB_SECR
 secrets[process.env.GITHUB_REPO_OWNER]['sol-rs'] = process.env.HUB_SECRET
 secrets[process.env.GITHUB_REPO_OWNER]['substrate'] = process.env.HUB_SECRET
 secrets[process.env.GITHUB_REPO_OWNER]['polkadot'] = process.env.HUB_SECRET
-secrets[process.env.GITHUB_REPO_OWNER][''] = process.env.HUB_SECRET
 
 # domain url
 domain = process.env.DOMAIN


### PR DESCRIPTION
Allow cla-bot to work with any repo that's defined in the cla-bot.coffee file ...
